### PR TITLE
fix ftp links / add zip decompression

### DIFF
--- a/biota/download.py
+++ b/biota/download.py
@@ -79,10 +79,6 @@ def generateURL(lat, lon, year, large_tile = False):
         # Filename patterns are different for ALOS-1/ALOS-2
         if year <= 2010:
             url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/PALSAR_MSC/25m_MSC/%s/%s_%s_MOS.tar.gz'
-        elif year > 2010 and year <= 2017:
-            url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext1/PALSAR-2_MSC/25m_MSC/%s/%s_%s_MOS_F02DAR.zip'
-        elif year == 2017:
-            url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext1/PALSAR-2_MSC/25m_MSC/%s/%s_%s_MOS_F02DAR.zip'
         else:
             url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext1/PALSAR-2_MSC/25m_MSC/%s/%s_%s_MOS_F02DAR.zip'
 
@@ -94,10 +90,6 @@ def generateURL(lat, lon, year, large_tile = False):
         # Filename patterns are different for ALOS-1/ALOS-2
         if year <= 2010:
             url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/PALSAR_MSC/25m_MSC/%s/%s/%s_%s_MOS.tar.gz'
-        elif year > 2010 and year <= 2017:
-            url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext1/PALSAR-2_MSC/25m_MSC/%s/%s/%s_%s_MOS_F02DAR.zip'
-        elif year == 2017:
-            url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext2/PALSAR-2_MSC/25m_MSC/%s/%s/%s_%s_MOS_F02DAR.zip'
         else:
             url = 'ftp://ftp.eorc.jaxa.jp/pub/ALOS-2/ext1/PALSAR-2_MSC/25m_MSC/%s/%s/%s_%s_MOS_F02DAR.zip'
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(name='biota',
       packages = ['biota'],
-      version='0.2',
+      version='0.3',
       description='Tools to generate aboveground biomass forest change maps from ALOS PALSAR/PALSAR-2 mosaic data.',
       url='https://bitbucket.org/sambowers/biota',
       data_files=[('./cfg/',glob.glob('./cfg/*'))],


### PR DESCRIPTION
After the last data re-processing for ALOS-2, the links in the FTP server changed. They have now been corrected and tested.

They also used zip compression for the ALOS-2 data, so the decompression function has been modified to handle both zip files and tar.gz flies.